### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: GitHub Exporter ${{ github.ref }}


### PR DESCRIPTION
I keep getting  bit by this.  Actions using the standard github token cannot kick off other actions.  We have to explicitly provide a PAT.  This is to prevent loops I think.