### PR TITLE
Fix broken links

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -105,7 +105,7 @@ OPTIONS
   --token=token        (required) GitHub personal access token
 ```
 
-_See code: [src/commands/repo.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/repo.ts)_
+_See code: [src/commands/repo.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/repo.ts)_
 
 ## `github-artifacts-exporter repo:commits`
 
@@ -126,7 +126,7 @@ OPTIONS
   --until=until        search commits created before yyyy-mm-dd
 ```
 
-_See code: [src/commands/repo/commits.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/repo/commits.ts)_
+_See code: [src/commands/repo/commits.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/repo/commits.ts)_
 
 ## `github-artifacts-exporter repo:milestones`
 
@@ -144,7 +144,7 @@ OPTIONS
   --token=token        (required) GitHub personal access token
 ```
 
-_See code: [src/commands/repo/milestones.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/repo/milestones.ts)_
+_See code: [src/commands/repo/milestones.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/repo/milestones.ts)_
 
 ## `github-artifacts-exporter repo:projects`
 
@@ -163,7 +163,7 @@ OPTIONS
   --token=token                  (required) GitHub personal access token
 ```
 
-_See code: [src/commands/repo/projects.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/repo/projects.ts)_
+_See code: [src/commands/repo/projects.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/repo/projects.ts)_
 
 ## `github-artifacts-exporter repo:pulls`
 
@@ -181,7 +181,7 @@ OPTIONS
   --token=token        (required) GitHub personal access token
 ```
 
-_See code: [src/commands/repo/pulls.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/repo/pulls.ts)_
+_See code: [src/commands/repo/pulls.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/repo/pulls.ts)_
 
 ## `github-artifacts-exporter repo:releases`
 
@@ -199,7 +199,7 @@ OPTIONS
   --token=token        (required) GitHub personal access token
 ```
 
-_See code: [src/commands/repo/releases.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/repo/releases.ts)_
+_See code: [src/commands/repo/releases.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/repo/releases.ts)_
 
 ## `github-artifacts-exporter search`
 
@@ -217,7 +217,7 @@ OPTIONS
   --token=token        (required) GitHub personal access token
 ```
 
-_See code: [src/commands/search.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/search.ts)_
+_See code: [src/commands/search.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/search.ts)_
 
 ## `github-artifacts-exporter search:issues`
 
@@ -244,5 +244,5 @@ OPTIONS
   --updatedUntil=updatedUntil  search issues updated before yyyy-mm-dd
 ```
 
-_See code: [src/commands/search/issues.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/src/commands/search/issues.ts)_
+_See code: [src/commands/search/issues.ts](https://github.com/github/github-artifact-exporter/blob/v2.0.1/packages/cli/src/commands/search/issues.ts)_
 <!-- commandsstop -->


### PR DESCRIPTION
README.md file for given package `@github/github-artifact-exporter-cli` has some broken links.