### PR TITLE
Adding body to output of the search query

### DIFF
--- a/packages/core/queries/searchIssues.graphql
+++ b/packages/core/queries/searchIssues.graphql
@@ -39,6 +39,7 @@ query searchIssues(
         }
         state
         title
+        body
         updatedAt
         milestone {
           title


### PR DESCRIPTION
Closes #43 
THis adds the issue body to the search query so it is returned in the JSON output.