### PR TITLE
Delete Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-# GitHub Security Policy
-
-Software security researchers are increasingly engaging with Internet companies to hunt down vulnerabilities. Our bounty program gives a tip of the hat to these researchers and provides rewards of $30,000 or more for critical vulnerabilities.
-
-If you’ve found a vulnerability, [submit it here](https://hackerone.com/github).
-
-You can find useful information in our [rules](https://bounty.github.com/#rules), [scope](https://bounty.github.com/#scope), [targets](https://bounty.github.com/#scope) and [FAQ](https://bounty.github.com/#faqs).


### PR DESCRIPTION
This PR deletes the Security policy as defined in this project in order to have it be default to, and be consistent with, GitHub's [org security policy](https://github.com/github/.github/blob/master/SECURITY.md).

\cc @philipturnbull 