### PR TITLE
Remove "used in production" line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # GitHub Exporter
-![Node.js CI](https://github.com/github/github-artifact-exporter/workflows/Node.js%20CI/badge.svg) ![Create release](https://github.com/github/github-artifact-exporter/workflows/Create%20release/badge.svg) ![Build and upload release assets](https://github.com/github/github-artifact-exporter/workflows/Build%20and%20upload%20release%20assets/badge.svg)  
-_Currently used in production_
+![Node.js CI](https://github.com/github/github-artifact-exporter/workflows/Node.js%20CI/badge.svg) ![Create release](https://github.com/github/github-artifact-exporter/workflows/Create%20release/badge.svg) ![Build and upload release assets](https://github.com/github/github-artifact-exporter/workflows/Build%20and%20upload%20release%20assets/badge.svg)
 
 ![Screenshot of the User interface](imgs/screenshot.png)
 


### PR DESCRIPTION
This PR removes the line in the README that says this project is "currently used in production", as this project is not hosted anywhere. 